### PR TITLE
jupyter_ydoc 3.4.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_ydoc" %}
-{% set version = "3.3.3" %}
+{% set version = "3.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/jupyter-server/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8e164ccfc4a8f660117a3c7c7b0f70d951916c2a58a8dc603aad85764c5c6515
+  sha256: 098a2333d718fcdd3cc1d906503120b905a7248b703f72939133c5c4fd57f35f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - anyio >=4.12.1,<5.0.0
     - pycrdt >=0.10.1,<0.13.0
 
-# pytest needs hypercorn  and httpx-ws in conftest.py, which are not available.
+# pytest needs hypercorn and httpx-ws in conftest.py, which are not available.
 test:
   imports:
     - jupyter_ydoc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - hatch-nodejs-version
   run:
     - python
+    - anyio >=4.12.1,<5.0.0
     - pycrdt >=0.10.1,<0.13.0
 
 # pytest needs hypercorn  and httpx-ws in conftest.py, which are not available.


### PR DESCRIPTION
jupyter_ydoc 3.4.1 

**Destination channel:** Defaults

### Links

- [PKG-14576]
- dev_url:        https://github.com/jupyter-server/jupyter_ydoc/tree/v3.4.1
- conda_forge:    https://github.com/conda-forge/jupyter_ydoc-feedstock
- pypi:           https://pypi.org/project/jupyter_ydoc/3.4.1
- pypi inspector: https://inspector.pypi.io/project/jupyter_ydoc/3.4.1

### Explanation of changes:

- new version number


[PKG-14576]: https://anaconda.atlassian.net/browse/PKG-14576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ